### PR TITLE
[Feature]: centralize and explicitly control number of benchmark runs

### DIFF
--- a/benchmarks/frameworks/crewai_benchmark.py
+++ b/benchmarks/frameworks/crewai_benchmark.py
@@ -26,9 +26,9 @@ from .common import (
 class CrewAIBenchmark(BaseBenchmark):
     """CrewAI framework benchmark implementation."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], num_runs: int = None):
         """Initialize CrewAI benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.llm: Optional[LLM] = None
         self.agents: Dict[str, Agent] = {}
         self.crews: Dict[str, Crew] = {}

--- a/benchmarks/frameworks/graphbit_benchmark.py
+++ b/benchmarks/frameworks/graphbit_benchmark.py
@@ -39,9 +39,9 @@ from .common import (
 class GraphBitBenchmark(BaseBenchmark):
     """Ultra-high-performance GraphBit benchmark using direct API calls."""
 
-    def __init__(self, config: Dict):
+    def __init__(self, config: Dict, num_runs: int = None):
         """Initialize GraphBit benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.llm_config = None
         self.llm_client = None
 

--- a/benchmarks/frameworks/langchain_benchmark.py
+++ b/benchmarks/frameworks/langchain_benchmark.py
@@ -26,9 +26,9 @@ from .common import (
 class LangChainBenchmark(BaseBenchmark):
     """LangChain framework benchmark implementation."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], num_runs: int = None):
         """Initialize LangChain benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.llm: Optional[Any] = None
         self.chains: Dict[str, PromptTemplate | Any] = {}
 

--- a/benchmarks/frameworks/langgraph_benchmark.py
+++ b/benchmarks/frameworks/langgraph_benchmark.py
@@ -44,9 +44,9 @@ class WorkflowState(TypedDict):
 class LangGraphBenchmark(BaseBenchmark):
     """LangGraph framework benchmark implementation."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], num_runs: int = None):
         """Initialize LangGraph benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.llm: Optional[Any] = None
         self.graphs: Dict[str, Any] = {}
 

--- a/benchmarks/frameworks/llamaindex_benchmark.py
+++ b/benchmarks/frameworks/llamaindex_benchmark.py
@@ -28,9 +28,9 @@ from .common import (
 class LlamaIndexBenchmark(BaseBenchmark):
     """LlamaIndex framework benchmark implementation."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], num_runs: int = None):
         """Initialize LlamaIndex benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.llm: Optional[Any] = None
         self.index: Optional[VectorStoreIndex] = None
         self.query_engine: Optional[Any] = None

--- a/benchmarks/frameworks/pydantic_ai_benchmark.py
+++ b/benchmarks/frameworks/pydantic_ai_benchmark.py
@@ -51,9 +51,9 @@ class ComplexResponse(BaseModel):
 class PydanticAIBenchmark(BaseBenchmark):
     """Pydantic AI framework benchmark implementation."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], num_runs: int = None):
         """Initialize PydanticAI benchmark with configuration."""
-        super().__init__(config)
+        super().__init__(config, num_runs=num_runs)
         self.model: Optional[Any] = None
         self.agents: Dict[str, Agent] = {}
 


### PR DESCRIPTION
- Move NUM_RUNS global default to a single location (default 5)
- Pass num_runs explicitly from runner to all framework benchmarks and loggers
- Remove circular imports between run_benchmark.py and common.py
- Add summary line to CLI output indicating averaging
- Add header to each per-framework log file with number of runs
- Update all relevant constructors and signatures for explicit num_runs usage
- Fixes issues with module imports