### PR TITLE
[Fix]: ensure pre-commit, cargo-deny, and license checks work cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ docs/build/
 */docs/build/
 .readthedocs.yml
 doc/
+*.txt
 
 # Test artifacts
 .nyc_output/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -192,12 +192,15 @@ repos:
     pass_filenames: false
 
       # Dependency vulnerability check
+      # Cross-platform compatible
   - id: cargo-deny
     name: Cargo deny check
-    entry: bash -c 'if command -v cargo-deny &> /dev/null; then cargo deny check; else echo "cargo-deny not installed, skipping"; fi'
+    entry: cargo deny check
     language: system
-    files: ^(Cargo\.toml|Cargo\.lock|.*/Cargo\.toml)$
     pass_filenames: false
+    require_serial: true
+
+
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 authors = ["GraphBit Team"]
 description = "GraphBit agentic workflow automation framework (library)"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 name = "graphbit"
 publish = false
 repository = "https://github.com/InfinitiBit/graphbit"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ python = ["pyo3"]
 authors = ["GraphBit Team"]
 description = "Core engine for GraphBit agentic workflow automation"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 name = "graphbit-core"
 repository = "https://github.com/InfinitiBit/graphbit"
 version = "0.1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,156 @@
+# This template contains all of the possible sections and their default values
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory databases are cloned/fetched into
+# db-path = "$CARGO_HOME/advisory-dbs"
+# The url(s) of the advisory databases to use
+# db-urls = ["https://github.com/rustsec/advisory-db"]
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# List of crates that are allowed. Use with care!
+allow = [
+]
+# List of crates to deny
+deny = [
+]
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# deny = ["bad-crate"]
+# allow = ["some-okay-crate@1.2.3"]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+]
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+# exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+]
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "BSD-2-Clause",
+  "ISC",
+  "0BSD",
+  "Unlicense",
+  "Unicode-3.0",
+  "Apache-2.0 WITH LLVM-exception"
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+]
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# List of URLs for allowed Git repositories
+allow-git = []
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+
+[sources.allow-org]
+# bitbucket.org organizations to allow git sources for
+bitbucket = []
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -30,6 +30,7 @@ crate-type = ["cdylib"]
 authors = ["GraphBit Team"]
 description = "Production-grade Python bindings for GraphBit agentic workflow automation"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 name = "graphbit"
 publish = false
 repository = "https://github.com/InfinitiBit/graphbit"


### PR DESCRIPTION

- Fix pre-commit hooks to work on both Windows and Linux/WSL (no more bash-only entries).
- Add and configure cargo-deny for Rust license compliance and security checks.
- Create and update deny.toml to allow all required open-source and Unicode licenses.
- Add license = "MIT OR Apache-2.0" to all internal crate Cargo.toml files (e.g., graphbit, graphbit-core).
- Remove obsolete/invalid config lines (e.g., enabled = true in [advisories]) from deny.toml.
- Tidy up .pre-commit-config.yaml for clarity and system compatibility.
- Run pretty-format-toml and other code quality hooks to ensure style and lint checks are enforced.