### PR TITLE
[Bugfix]: add macOS fallback for sched_getaffinity

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -24,11 +24,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
-if sys.platform == "win32":
+if sys.platform == "win32" or sys.platform == "darwin":
 
-    def sched_getaffinity(pid):
-        """Fallback for Windows to get CPU affinity."""
-        return set(range(os.cpu_count() or 4))  # 👈 fallback handled here
+    def sched_getaffinity(pid=0):
+        """Fallback for macOS and Windows to get CPU affinity."""
+        return set(range(os.cpu_count() or 4))  # safe fallback
 
 else:
     from os import sched_getaffinity
@@ -53,6 +53,7 @@ sys.path.insert(0, str(benchmarks_path))
 
 def _default_concurrency() -> int:
     return len(sched_getaffinity(0))
+
 
 # Central global variable for number of runs
 NUM_RUNS = 10

--- a/examples/chatbot/backend/const.py
+++ b/examples/chatbot/backend/const.py
@@ -4,11 +4,13 @@ Configuration constants for the GraphBit chatbot backend.
 This module contains all the configuration constants used throughout the chatbot
 application, including file paths, model settings, and API configurations.
 """
+
 import os
 
 
 class ConfigConstants:
     """Centralized configuration constants for the chatbot backend."""
+
     VECTOR_DB_TEXT_FILE = "backend/data/vectordb.txt"
     VECTOR_DB_INDEX_NAME = "vector_index_chatbot"
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")


### PR DESCRIPTION
 fixes an ImportError on macOS caused by attempting to import sched_getaffinity from the os module, which is only available on Linux. It adds a platform check using sys.platform and provides a safe fallback implementation for macOS and Windows using os.cpu_count().