### PR TITLE
[Bugfix]: make GraphBit benchmark CPU affinity logic cross-platform (macOS support, safe fallback)

### DIFF
--- a/benchmarks/frameworks/common.py
+++ b/benchmarks/frameworks/common.py
@@ -3,6 +3,7 @@
 import gc
 import logging
 import os
+import platform
 import shutil
 import sys
 import time
@@ -497,6 +498,16 @@ def set_process_affinity(cores: Optional[List[int]]) -> None:
     """Apply CPU affinity to the current process if ``cores`` provided."""
     if cores and psutil is not None:
         psutil.Process().cpu_affinity(cores)
+
+
+def get_cpu_affinity_or_count_fallback() -> int:
+    """Get the number of CPU cores available or the current CPU affinity."""
+    if platform.system() in ("Linux", "Windows"):
+        try:
+            return len(psutil.Process().cpu_affinity())
+        except Exception:
+            return os.cpu_count() or 4
+    return os.cpu_count() or 4
 
 
 def set_memory_binding(node: Optional[int]) -> None:

--- a/benchmarks/frameworks/graphbit_benchmark.py
+++ b/benchmarks/frameworks/graphbit_benchmark.py
@@ -10,8 +10,6 @@ import os
 import sys
 from typing import Dict, Optional
 
-import psutil
-
 try:
     import graphbit
 except ImportError:
@@ -32,6 +30,7 @@ from .common import (
     LLMProvider,
     calculate_throughput,
     count_tokens_estimate,
+    get_cpu_affinity_or_count_fallback,
     get_standard_llm_config,
 )
 
@@ -58,8 +57,7 @@ class GraphBitBenchmark(BaseBenchmark):
         """Set up GraphBit with minimal overhead configuration - DIRECT API ONLY."""
         # Align runtime worker threads with the current CPU affinity so the runtime
         # uses only the pinned CPU cores
-        affinity = psutil.Process().cpu_affinity()
-        graphbit.configure_runtime(worker_threads=len(affinity))
+        graphbit.configure_runtime(worker_threads=get_cpu_affinity_or_count_fallback())
 
         # Initialize GraphBit core only (skip workflow system)
         # Use debug=False for benchmarks to minimize overhead


### PR DESCRIPTION

- Only use psutil.cpu_affinity on Linux/Windows
- Fallback to os.cpu_count() on macOS and other unsupported platforms
- Prevents AttributeError on macOS, ensures benchmarks run everywhere