### PR TITLE
[Feature] Rust Core, Rust Python Binding: Agentic Workflow with Dep-Batching and Parent Preamble

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ async-trait = "0.1"
 chrono = {version = "0.4", features = ["serde"]}
 docx-rs = "0.4"
 futures = "0.3"
+lazy_static = "1.4"
 lopdf = "0.32"
 petgraph = "0.6"
 rand = "0.8"

--- a/core/src/graph.rs
+++ b/core/src/graph.rs
@@ -385,6 +385,14 @@ impl WorkflowGraph {
     pub fn edge_count(&self) -> usize {
         self.edges.len()
     }
+
+    /// Get node ID by name
+    pub fn get_node_id_by_name(&self, name: &str) -> Option<NodeId> {
+        self.nodes
+            .values()
+            .find(|node| node.name == name)
+            .map(|node| node.id.clone())
+    }
 }
 
 impl Default for WorkflowGraph {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,9 @@ pub mod types;
 pub mod validation;
 pub mod workflow;
 
+#[cfg(test)]
+mod workflow_tests;
+
 // Re-export important types for convenience - only keep what's actually used
 pub use agents::{Agent, AgentBuilder, AgentConfig, AgentTrait};
 pub use document_loader::{DocumentContent, DocumentLoader, DocumentLoaderConfig};

--- a/core/src/workflow_tests.rs
+++ b/core/src/workflow_tests.rs
@@ -1,0 +1,212 @@
+#[cfg(test)]
+mod tests {
+    use crate::types::{NodeId, WorkflowContext, WorkflowId};
+    use crate::workflow::WorkflowExecutor;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn test_workflow_context_node_outputs() {
+        let mut context = WorkflowContext::new(WorkflowId::new());
+        let node_id = NodeId::from_string("test_node").unwrap();
+        let output = json!({
+            "result": "success",
+            "data": {
+                "value": 42,
+                "nested": {
+                    "key": "nested_value"
+                }
+            }
+        });
+
+        // Store output
+        context.set_node_output(&node_id, output.clone());
+
+        // Retrieve and verify
+        let stored = context.get_node_output("test_node").unwrap();
+        assert_eq!(stored, &output);
+
+        // Test nested access
+        let nested_value = context.get_nested_output("test_node.data.value").unwrap();
+        assert_eq!(nested_value, &json!(42));
+
+        let deeply_nested = context
+            .get_nested_output("test_node.data.nested.key")
+            .unwrap();
+        assert_eq!(deeply_nested, &json!("nested_value"));
+    }
+
+    #[tokio::test]
+    async fn test_template_resolution() {
+        let mut context = WorkflowContext::new(WorkflowId::new());
+
+        // Set up test data
+        context
+            .variables
+            .insert("name".to_string(), json!("Test User"));
+        context.node_outputs.insert(
+            "node1".to_string(),
+            json!({
+                "result": "Success",
+                "data": {
+                    "value": 42,
+                    "nested": {
+                        "key": "nested_value"
+                    }
+                }
+            }),
+        );
+
+        // Test simple variable substitution
+        let template = "Hello, {name}!";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Hello, Test User!");
+
+        // Test node reference
+        let template = "Status: {{node.node1.result}}";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Status: Success");
+
+        // Test nested property access
+        let template = "Value: {{node.node1.data.value}}";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Value: 42");
+
+        // Test deeply nested property
+        let template = "Nested: {{node.node1.data.nested.key}}";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Nested: nested_value");
+
+        // Test mixed variables
+        let template =
+            "Hello {name}, status: {{node.node1.result}}, value: {{node.node1.data.value}}";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Hello Test User, status: Success, value: 42");
+
+        // Test non-existent references
+        let template = "Missing: {{node.nonexistent}}";
+        let result = WorkflowExecutor::resolve_template_variables(template, &context);
+        assert_eq!(result, "Missing: {{node.nonexistent}}");
+    }
+
+    #[tokio::test]
+    async fn test_template_resolution_edge_cases() {
+        let context = WorkflowContext::new(WorkflowId::new());
+
+        // Test empty template
+        let result = WorkflowExecutor::resolve_template_variables("", &context);
+        assert_eq!(result, "");
+
+        // Test template with no variables
+        let result = WorkflowExecutor::resolve_template_variables("No variables here", &context);
+        assert_eq!(result, "No variables here");
+
+        // Test malformed references
+        let result = WorkflowExecutor::resolve_template_variables("{{node.}}", &context);
+        assert_eq!(result, "{{node.}}");
+
+        let result = WorkflowExecutor::resolve_template_variables("{{node}}", &context);
+        assert_eq!(result, "{{node}}");
+
+        // Test nested braces
+        let result = WorkflowExecutor::resolve_template_variables("{{{node.test}}}", &context);
+        assert_eq!(result, "{{{node.test}}}");
+    }
+
+    #[tokio::test]
+    async fn test_node_output_storage_during_execution() {
+        // This test would require a more complex setup with actual agents
+        // For now, we'll test the storage mechanism directly
+        let context = Arc::new(Mutex::new(WorkflowContext::new(WorkflowId::new())));
+        let node_id = NodeId::from_string("test_node").unwrap();
+        let output = json!({"result": "test_output"});
+
+        // Simulate node execution storing output
+        {
+            let mut ctx = context.lock().await;
+            ctx.set_node_output(&node_id, output.clone());
+        }
+
+        // Verify output was stored
+        {
+            let ctx = context.lock().await;
+            let stored = ctx.get_node_output("test_node").unwrap();
+            assert_eq!(stored, &output);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_context_serialization() {
+        let mut context = WorkflowContext::new(WorkflowId::new());
+        context
+            .variables
+            .insert("test_var".to_string(), json!("test_value"));
+        context
+            .node_outputs
+            .insert("test_node".to_string(), json!({"output": "test"}));
+
+        // Test serialization
+        let serialized = serde_json::to_string(&context).unwrap();
+        let deserialized: WorkflowContext = serde_json::from_str(&serialized).unwrap();
+
+        // Verify data is preserved
+        assert_eq!(
+            deserialized.variables.get("test_var"),
+            Some(&json!("test_value"))
+        );
+        assert_eq!(
+            deserialized.node_outputs.get("test_node"),
+            Some(&json!({"output": "test"}))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_large_node_outputs() {
+        let mut context = WorkflowContext::new(WorkflowId::new());
+        let node_id = NodeId::from_string("large_node").unwrap();
+
+        // Create a large output (1MB string)
+        let large_string = "x".repeat(1024 * 1024);
+        let large_output = json!({"data": large_string});
+
+        // Store and retrieve large output
+        context.set_node_output(&node_id, large_output.clone());
+        let retrieved = context.get_node_output("large_node").unwrap();
+        assert_eq!(retrieved, &large_output);
+
+        // Test nested access on large output
+        let nested_data = context.get_nested_output("large_node.data").unwrap();
+        assert_eq!(nested_data, &json!(large_string));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_node_output_access() {
+        let context = Arc::new(Mutex::new(WorkflowContext::new(WorkflowId::new())));
+        let node_id = NodeId::from_string("concurrent_node").unwrap();
+        let output = json!({"concurrent": "test"});
+
+        // Store output from one task
+        let context_clone = context.clone();
+        let output_clone = output.clone();
+        let store_task = tokio::spawn(async move {
+            let mut ctx = context_clone.lock().await;
+            ctx.set_node_output(&node_id, output_clone);
+        });
+
+        // Read output from another task
+        let context_clone2 = context.clone();
+        let read_task = tokio::spawn(async move {
+            // Wait a bit to ensure store happens first
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            let ctx = context_clone2.lock().await;
+            ctx.get_node_output("concurrent_node").cloned()
+        });
+
+        // Wait for both tasks
+        store_task.await.unwrap();
+        let result = read_task.await.unwrap();
+
+        assert_eq!(result, Some(output));
+    }
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -69,7 +69,7 @@ pub use text_splitter::{
     CharacterSplitter, RecursiveSplitter, SentenceSplitter, TextChunk, TextSplitterConfig,
     TokenSplitter,
 };
-pub use workflow::{Executor, Node, Workflow, WorkflowResult};
+pub use workflow::{Executor, Node, Workflow, WorkflowContext, WorkflowResult};
 
 /// Global initialization flag to ensure init is called only once
 static INIT: Once = Once::new();
@@ -364,6 +364,7 @@ fn graphbit(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Workflow classes
     m.add_class::<Node>()?;
     m.add_class::<Workflow>()?;
+    m.add_class::<WorkflowContext>()?;
     m.add_class::<WorkflowResult>()?;
     m.add_class::<Executor>()?;
 

--- a/python/src/workflow/context.rs
+++ b/python/src/workflow/context.rs
@@ -1,0 +1,158 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyString};
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+#[pyclass]
+#[derive(Clone)]
+pub struct WorkflowContext {
+    pub(crate) inner: graphbit_core::types::WorkflowContext,
+}
+
+#[pymethods]
+impl WorkflowContext {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: graphbit_core::types::WorkflowContext::new(
+                graphbit_core::types::WorkflowId::new(),
+            ),
+        }
+    }
+
+    /// Set a variable in the context
+    fn set_variable(&mut self, key: String, value: PyObject, py: Python<'_>) -> PyResult<()> {
+        // Convert Python object to JSON value
+        let json_value = if let Ok(s) = value.extract::<String>(py) {
+            JsonValue::String(s)
+        } else if let Ok(b) = value.extract::<bool>(py) {
+            JsonValue::Bool(b)
+        } else if let Ok(i) = value.extract::<i64>(py) {
+            JsonValue::Number(serde_json::Number::from(i))
+        } else if let Ok(f) = value.extract::<f64>(py) {
+            JsonValue::Number(
+                serde_json::Number::from_f64(f).unwrap_or(serde_json::Number::from(0)),
+            )
+        } else {
+            // Try to serialize as JSON string
+            let json_str = format!("{}", value);
+            JsonValue::String(json_str)
+        };
+
+        self.inner.variables.insert(key, json_value);
+        Ok(())
+    }
+
+    /// Get a variable from the context
+    fn get_variable(&self, key: &str, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        match self.inner.variables.get(key) {
+            Some(value) => {
+                let py_obj = json_to_python(value, py)?;
+                Ok(Some(py_obj))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Get a node's output from the context
+    fn get_node_output(&self, node_id: &str, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        match self.inner.get_node_output(node_id) {
+            Some(value) => {
+                let py_obj = json_to_python(value, py)?;
+                Ok(Some(py_obj))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Get a nested value from a node's output using dot notation
+    fn get_nested_output(&self, reference: &str, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        match self.inner.get_nested_output(reference) {
+            Some(value) => {
+                let py_obj = json_to_python(value, py)?;
+                Ok(Some(py_obj))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Convert the context variables to a Python dictionary
+    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        for (k, v) in &self.inner.variables {
+            let py_value = json_to_python(v, py)?;
+            dict.set_item(k, py_value)?;
+        }
+        Ok(dict.into())
+    }
+
+    /// Get all node outputs as a dictionary
+    fn get_all_node_outputs(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        for (k, v) in &self.inner.node_outputs {
+            let py_value = json_to_python(v, py)?;
+            dict.set_item(k, py_value)?;
+        }
+        Ok(dict.into())
+    }
+
+    /// Get the workflow ID
+    fn get_workflow_id(&self) -> String {
+        self.inner.workflow_id.to_string()
+    }
+
+    /// Get the workflow state
+    fn get_state(&self) -> String {
+        format!("{:?}", self.inner.state)
+    }
+
+    /// Check if the workflow is completed
+    fn is_completed(&self) -> bool {
+        matches!(
+            self.inner.state,
+            graphbit_core::types::WorkflowState::Completed
+        )
+    }
+
+    /// Check if the workflow has failed
+    fn is_failed(&self) -> bool {
+        matches!(
+            self.inner.state,
+            graphbit_core::types::WorkflowState::Failed { .. }
+        )
+    }
+}
+
+/// Helper function to convert JSON values to Python objects
+fn json_to_python(value: &JsonValue, py: Python<'_>) -> PyResult<PyObject> {
+    match value {
+        JsonValue::String(s) => Ok(s.clone().into_py(py)),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.into_py(py))
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.into_py(py))
+            } else {
+                Ok(n.to_string().into_py(py))
+            }
+        }
+        JsonValue::Bool(b) => Ok(b.into_py(py)),
+        JsonValue::Null => Ok(py.None()),
+        JsonValue::Array(arr) => {
+            let py_list = pyo3::types::PyList::empty(py);
+            for item in arr {
+                let py_item = json_to_python(item, py)?;
+                py_list.append(py_item)?;
+            }
+            Ok(py_list.into())
+        }
+        JsonValue::Object(obj) => {
+            let py_dict = PyDict::new(py);
+            for (k, v) in obj {
+                let py_value = json_to_python(v, py)?;
+                py_dict.set_item(k, py_value)?;
+            }
+            Ok(py_dict.into())
+        }
+    }
+}

--- a/python/src/workflow/mod.rs
+++ b/python/src/workflow/mod.rs
@@ -1,10 +1,12 @@
 //! Workflow module for GraphBit Python bindings
 
+pub(crate) mod context;
 pub(crate) mod executor;
 pub(crate) mod node;
 pub(crate) mod result;
 pub(crate) mod workflow;
 
+pub use context::WorkflowContext;
 pub use executor::Executor;
 pub use node::Node;
 pub use result::WorkflowResult;


### PR DESCRIPTION
Rust Core: 
- Strict parent-child dep batching with debug tracing.
- Agentic preamble: inject parents’ outputs (by ID/name) into prompt.
- Template refs.
- Dual-key output storage (NodeId and name) with stringified vars. 
- Result attribution now includes node_id.

Rust Python Binding:
- Expose WorkflowContext: var/node get/set, nested outputs, state helpers.
- Bindings wiring for new context API.

No breaking changes; legacy interpolation and name-based access remain.
