### PR TITLE
[BugFix] : connection edge cases, unique IDs, and cyclic workflow checks

### DIFF
--- a/python/src/workflow/workflow.rs
+++ b/python/src/workflow/workflow.rs
@@ -73,4 +73,13 @@ impl Workflow {
     fn name(&self) -> String {
         self.inner.name.clone()
     }
+
+    /// Set graph-level metadata key to a boolean value
+    /// Exposes core graph.set_metadata for Python tests and configuration
+    fn set_graph_metadata(&mut self, key: String, value: bool) -> PyResult<()> {
+        self.inner
+            .graph
+            .set_metadata(key, serde_json::Value::Bool(value));
+        Ok(())
+    }
 }


### PR DESCRIPTION
- Self-loop prevention: Blocks same-node connections to avoid "Error: Already Exists".
- Node renaming: Resolves duplicate node conflicts when names clash.
- Agent ID uniqueness: Enforces that the same agent ID cannot be reused.
- Concurrent agent execution: Improves handling to avoid race conditions.
- Cyclic workflow protection: Detects and safeguards against workflow loops.
