### PR TITLE
[Fix] sentence splitter issue

### DIFF
--- a/core/src/text_splitter.rs
+++ b/core/src/text_splitter.rs
@@ -547,11 +547,13 @@ impl TextSplitterTrait for SentenceSplitter {
             }
 
             // Move to next chunk with overlap
-            i = if self.chunk_overlap > 0 && j < sentences.len() {
+            let next_i = if self.chunk_overlap > 0 && j < sentences.len() {
                 j.saturating_sub(self.chunk_overlap)
             } else {
                 j
             };
+
+            i = next_i.max(i + 1);
         }
 
         Ok(chunks)


### PR DESCRIPTION
When number of sentences in a chunk was less than or equal to `chunk_overlap` value. Sentence Splitter was starting from the same index again and again causing it to fall into an infinite loop. Handled that in this PR.