### PR TITLE
[Fix] Infinite loop issue from character splitter

### DIFF
--- a/core/src/text_splitter.rs
+++ b/core/src/text_splitter.rs
@@ -268,11 +268,13 @@ impl TextSplitterTrait for CharacterSplitter {
             }
 
             // Move to next chunk with overlap
-            char_start = if self.chunk_overlap > 0 && char_end < total_chars {
+            let next_char_start = if self.chunk_overlap > 0 && char_end < total_chars {
                 char_end.saturating_sub(self.chunk_overlap)
             } else {
                 char_end
             };
+
+            char_start = next_char_start.max(char_start + 1);
         }
 
         Ok(chunks)


### PR DESCRIPTION
### Reason
In the `TextSplitterConfig` for specifically `CharacterSplitter` the value for `preserve_word_boundaries` which was trying to prevent chunks to end in a broken word and crop the chunk just before the whitespace.
"This is a test text for character splitting" and `chunk_size=10`, `chunk_overlap=2`
for this text at some point the chunk becomes `r characte` and crops it to `r ` and keeps looping as the next word never finishes with the chunk size.

### Solution
Always starting the next chunk from at least one character after the current starting chunk.