### PR TITLE
[Bugfix] Perplexity prompt error fix.

### DIFF
--- a/core/src/agents.rs
+++ b/core/src/agents.rs
@@ -153,12 +153,11 @@ impl Agent {
 
     /// Build an LLM request from a message
     fn build_llm_request(&self, message: &AgentMessage) -> LlmRequest {
-        let mut request = LlmRequest::new("");
+        let mut messages = Vec::new();
 
         // Add system prompt if available
         if !self.config.system_prompt.is_empty() {
-            request =
-                request.with_message(crate::llm::LlmMessage::system(&self.config.system_prompt));
+            messages.push(crate::llm::LlmMessage::system(&self.config.system_prompt));
         }
 
         // Add the user message
@@ -189,7 +188,10 @@ impl Agent {
             }
         };
 
-        request = request.with_message(crate::llm::LlmMessage::user(content));
+        messages.push(crate::llm::LlmMessage::user(content));
+
+        // Create request with messages
+        let mut request = LlmRequest::with_messages(messages);
 
         // Apply configuration
         if let Some(max_tokens) = self.config.max_tokens {


### PR DESCRIPTION
The LlmRequest::new("") constructor automatically creates a user message with empty content, which resulted in:

- Message 0: role='user', content='' (empty!)
- Message 1: role='user', content='[Task]\nSay hello and calculate 2+2'

This violated Perplexity's API requirement that user and assistant messages must alternate, and Perplexity doesn't accept empty content.

The Fix

I changed the agent's build_llm_request method to:

1. Build a vector of messages manually instead of starting with an empty user message
2. Only add a system message if the system prompt is not empty
3. Add the actual user message with content
4. Create the LlmRequest using LlmRequest::with_messages(messages)