### PR TITLE
[Docs] updated root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,20 @@ Designed to run **multi-agent workflows in parallel**, Graphbit persists memory 
 ##  Quick Start
 
 ### Installation
+Set up poetry environment, then install dependencies
 ```bash
-pip install graphbit
+poetry install --no-root
+```
+Build Python bindings
+```bash
+cd python/
+cargo clean
+maturin develop
 ```
 
 ### Environment Setup
 First, set up your API keys:
 ```bash
-# Copy the example environment file
-cp .env.example .env
-
-# Or set directly
 export OPENAI_API_KEY=your_openai_api_key_here
 export ANTHROPIC_API_KEY=your_anthropic_api_key_here
 ```


### PR DESCRIPTION
Replace dev install instructions with maturin develop (temp, for faster local builds). 

Remove the “Copy the example environment file” section (cp .env.example .env).

Keep direct env-var exports (export OPENAI_API_KEY=…, export ANTHROPIC_API_KEY=…).