### PR TITLE
[Bugfix] llm provider configuration : Enable auto-detection of LLM config from user input (remove defaults)

### DIFF
--- a/core/src/llm/mod.rs
+++ b/core/src/llm/mod.rs
@@ -332,6 +332,10 @@ impl LlmProviderFactory {
                 "Unsupported custom provider: {}",
                 provider_type
             ))),
+            LlmConfig::Unconfigured { message } => Err(GraphBitError::config(format!(
+                "LLM provider not configured: {}",
+                message
+            ))),
         }
     }
 

--- a/core/src/llm/openrouter.rs
+++ b/core/src/llm/openrouter.rs
@@ -135,9 +135,10 @@ impl OpenRouterProvider {
 
     /// Parse OpenRouter response to GraphBit response
     fn parse_response(&self, response: OpenRouterResponse) -> GraphBitResult<LlmResponse> {
-        let choice = response.choices.into_iter().next().ok_or_else(|| {
-            GraphBitError::llm_provider("openrouter", "No choices in response")
-        })?;
+        let choice =
+            response.choices.into_iter().next().ok_or_else(|| {
+                GraphBitError::llm_provider("openrouter", "No choices in response")
+            })?;
 
         let content = choice.message.content.unwrap_or_default();
         let tool_calls = choice
@@ -277,24 +278,26 @@ impl LlmProviderTrait for OpenRouterProvider {
             "openai/gpt-4-turbo" => Some(128000),
             "openai/gpt-4" => Some(8192),
             "openai/gpt-3.5-turbo" => Some(16385),
-            
+
             // Anthropic models
             "anthropic/claude-3-5-sonnet" | "anthropic/claude-3-5-haiku" => Some(200000),
-            "anthropic/claude-3-opus" | "anthropic/claude-3-sonnet" | "anthropic/claude-3-haiku" => Some(200000),
-            
+            "anthropic/claude-3-opus"
+            | "anthropic/claude-3-sonnet"
+            | "anthropic/claude-3-haiku" => Some(200000),
+
             // Google models
             "google/gemini-pro" => Some(32768),
             "google/gemini-pro-1.5" => Some(1000000),
-            
+
             // Meta models
             "meta-llama/llama-3.1-405b-instruct" => Some(131072),
             "meta-llama/llama-3.1-70b-instruct" => Some(131072),
             "meta-llama/llama-3.1-8b-instruct" => Some(131072),
-            
+
             // Mistral models
             "mistralai/mistral-large" => Some(128000),
             "mistralai/mistral-medium" => Some(32768),
-            
+
             // Default for unknown models
             _ => Some(4096),
         }
@@ -310,13 +313,13 @@ impl LlmProviderTrait for OpenRouterProvider {
             "openai/gpt-4-turbo" => Some((0.00001, 0.00003)),
             "openai/gpt-4" => Some((0.00003, 0.00006)),
             "openai/gpt-3.5-turbo" => Some((0.0000005, 0.0000015)),
-            
+
             // Anthropic models
             "anthropic/claude-3-5-sonnet" => Some((0.000003, 0.000015)),
             "anthropic/claude-3-opus" => Some((0.000015, 0.000075)),
             "anthropic/claude-3-sonnet" => Some((0.000003, 0.000015)),
             "anthropic/claude-3-haiku" => Some((0.00000025, 0.00000125)),
-            
+
             // Many other models on OpenRouter are free or very low cost
             _ => None,
         }

--- a/core/src/llm/providers.rs
+++ b/core/src/llm/providers.rs
@@ -84,6 +84,11 @@ pub enum LlmConfig {
         /// Custom configuration parameters
         config: HashMap<String, serde_json::Value>,
     },
+    /// Unconfigured state - requires explicit configuration
+    Unconfigured {
+        /// Error message explaining the configuration requirement
+        message: String,
+    },
 }
 
 impl LlmConfig {
@@ -187,6 +192,7 @@ impl LlmConfig {
             LlmConfig::Perplexity { .. } => "perplexity",
             LlmConfig::OpenRouter { .. } => "openrouter",
             LlmConfig::Custom { provider_type, .. } => provider_type,
+            LlmConfig::Unconfigured { .. } => "unconfigured",
         }
     }
 
@@ -204,16 +210,16 @@ impl LlmConfig {
                 .get("model")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown"),
+            LlmConfig::Unconfigured { .. } => "none",
         }
     }
 }
 
 impl Default for LlmConfig {
-    /// Default configuration uses Ollama with llama3.2 model for local development
+    /// Default configuration requires explicit setup - no hardcoded provider defaults
     fn default() -> Self {
-        Self::Ollama {
-            model: "llama3.2".to_string(),
-            base_url: None,
+        Self::Unconfigured {
+            message: "LLM provider not configured. Please explicitly set an LLM configuration using LlmConfig::openai(), LlmConfig::anthropic(), etc.".to_string(),
         }
     }
 }

--- a/core/src/workflow.rs
+++ b/core/src/workflow.rs
@@ -298,7 +298,7 @@ impl WorkflowExecutor {
 
         // 3. No default fallback - require explicit configuration as requested by user
         tracing::error!("No LLM configuration found - neither node-level nor executor-level config provided. System requires explicit configuration.");
-        crate::llm::LlmConfig::Unconfigured { 
+        crate::llm::LlmConfig::Unconfigured {
             message: "No LLM configuration provided. The system requires explicit configuration from program or user input rather than hardcoded defaults.".to_string()
         }
     }

--- a/core/src/workflow.rs
+++ b/core/src/workflow.rs
@@ -265,7 +265,7 @@ impl WorkflowExecutor {
     }
 
     /// Resolve LLM configuration for a node with hierarchical priority
-    /// Priority: Node-level config > Executor-level config > Default
+    /// Priority: Node-level config > Executor-level config > ERROR (no defaults)
     fn resolve_llm_config_for_node(
         &self,
         node_config: &std::collections::HashMap<String, serde_json::Value>,
@@ -296,13 +296,11 @@ impl WorkflowExecutor {
             return executor_config.clone();
         }
 
-        // 3. Use default configuration (lowest priority)
-        let default_config = crate::llm::LlmConfig::default();
-        tracing::debug!(
-            "Using default LLM configuration: {:?}",
-            default_config.provider_name()
-        );
-        default_config
+        // 3. No default fallback - require explicit configuration as requested by user
+        tracing::error!("No LLM configuration found - neither node-level nor executor-level config provided. System requires explicit configuration.");
+        crate::llm::LlmConfig::Unconfigured { 
+            message: "No LLM configuration provided. The system requires explicit configuration from program or user input rather than hardcoded defaults.".to_string()
+        }
     }
 
     /// Get or create circuit breaker for an agent
@@ -373,8 +371,10 @@ impl WorkflowExecutor {
                 if !agent_exists {
                     // Find the node configuration for this agent to extract system_prompt and LLM config
                     let mut system_prompt = String::new();
-                    let mut resolved_llm_config =
-                        self.default_llm_config.clone().unwrap_or_default();
+                    let mut resolved_llm_config = self.default_llm_config.clone()
+                        .unwrap_or_else(|| crate::llm::LlmConfig::Unconfigured {
+                            message: "No LLM configuration provided for agent creation. Please explicitly configure an LLM provider.".to_string()
+                        });
 
                     for node in workflow.graph.get_nodes().values() {
                         if let NodeType::Agent {

--- a/python/src/workflow/executor.rs
+++ b/python/src/workflow/executor.rs
@@ -640,13 +640,14 @@ impl Executor {
                                                 v.clone(),
                                             )
                                             .ok()
-                                        })
-                                        .unwrap_or_default();
+                                        });
 
-                                    // Create the LLM provider using the factory
-                                    match graphbit_core::llm::LlmProviderFactory::create_provider(
-                                        llm_config.clone(),
-                                    ) {
+                                    // Only proceed if we have an explicit LLM configuration
+                                    if let Some(llm_config) = llm_config {
+                                        // Create the LLM provider using the factory
+                                        match graphbit_core::llm::LlmProviderFactory::create_provider(
+                                            llm_config.clone(),
+                                        ) {
                                         Ok(provider_trait) => {
                                             let llm_provider =
                                                 LlmProvider::new(provider_trait, llm_config);
@@ -716,6 +717,14 @@ impl Executor {
                                             );
                                         }
                                     }
+                                } else {
+                                    // No LLM configuration available, just keep tool results
+                                    tracing::warn!("No LLM configuration found in context metadata for final response. Using tool results only.");
+                                    context.set_node_output(
+                                        &node.id,
+                                        serde_json::Value::String(tool_results.clone()),
+                                    );
+                                }
                                 }
                             }
                         }

--- a/python/src/workflow/executor.rs
+++ b/python/src/workflow/executor.rs
@@ -632,10 +632,8 @@ impl Executor {
                                     &node.node_type
                                 {
                                     // Create a simple LLM request for the final response
-                                    let llm_config = context
-                                        .metadata
-                                        .get("llm_config")
-                                        .and_then(|v| {
+                                    let llm_config =
+                                        context.metadata.get("llm_config").and_then(|v| {
                                             serde_json::from_value::<graphbit_core::llm::LlmConfig>(
                                                 v.clone(),
                                             )
@@ -717,14 +715,14 @@ impl Executor {
                                             );
                                         }
                                     }
-                                } else {
-                                    // No LLM configuration available, just keep tool results
-                                    tracing::warn!("No LLM configuration found in context metadata for final response. Using tool results only.");
-                                    context.set_node_output(
-                                        &node.id,
-                                        serde_json::Value::String(tool_results.clone()),
-                                    );
-                                }
+                                    } else {
+                                        // No LLM configuration available, just keep tool results
+                                        tracing::warn!("No LLM configuration found in context metadata for final response. Using tool results only.");
+                                        context.set_node_output(
+                                            &node.id,
+                                            serde_json::Value::String(tool_results.clone()),
+                                        );
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
fix(llm): eliminate hardcoded Ollama default fallback

BREAKING CHANGE: LlmConfig now requires explicit configuration instead of defaulting to Ollama

- Add LlmConfig::Unconfigured variant to represent unset state
- Update Default::default() to return Unconfigured instead of Ollama  
- Fix workflow config resolution to avoid .unwrap_or_default() patterns
- Fix Python executor tool response path fallback
- Add proper error handling in LlmProviderFactory

Resolves persistent "localhost:11434" errors when using OpenAI/other providers.