### PR TITLE
[BugFix]: Organize artifacts for NAPI-RS in workflow

### DIFF
--- a/.github/workflows/js-ts-release.yml
+++ b/.github/workflows/js-ts-release.yml
@@ -167,15 +167,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: javascript/artifacts
-          merge-multiple: true  # Flatten all artifacts into single directory
 
-      - name: Install npm dependencies
+      - name: Organize artifacts for NAPI-RS
         working-directory: javascript
-        run: npm ci
-
-      - name: Prepare artifacts for publishing
-        working-directory: javascript
-        run: npm run artifacts
+        run: |
+          echo "📦 Moving artifacts to root directory..."
+          # NAPI-RS expects .node files in root after artifacts command
+          # Since we downloaded manually, move them directly to root
+          find artifacts -name "*.node" -exec mv {} . \;
+          
+          echo "✅ Artifacts moved. Contents:"
+          ls -lh *.node
 
       - name: Verify platform binaries exist
         working-directory: javascript


### PR DESCRIPTION
Updated the workflow to organize artifacts for NAPI-RS and removed the npm run artifacts step.